### PR TITLE
Refactor `save_own_variables` and `load_own_variables` to use the names as the keys.

### DIFF
--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -235,52 +235,26 @@ class Dense(Layer):
         # Do nothing if the layer isn't yet built
         if not self.built:
             return
-        # The keys of the `store` will be saved as determined because the
-        # default ordering will change after quantization
         mode = self.quantization_mode
-
-        # For int4/int8, the merged LoRA scale (if any) comes from
-        # `_get_kernel_with_merged_lora()` and is appended below.
-        MODE_SPEC = {
-            None: [],
-            "int4": [],
-            "int8": [],
-            "float8": [
-                "inputs_scale",
-                "inputs_amax_history",
-                "kernel_scale",
-                "kernel_amax_history",
-                "outputs_grad_scale",
-                "outputs_grad_amax_history",
-            ],
-            "gptq": [
-                "quantized_kernel",
-                "kernel_scale",
-                "kernel_zero",
-                "g_idx",
-            ],
-        }
-
-        if mode not in MODE_SPEC:
+        if mode not in self.quantization_variable_spec:
             raise self._quantization_mode_error(mode)
 
         # Kernel plus optional merged LoRA-aware scale (returns (kernel, None)
         # for None/gptq)
         kernel_value, merged_kernel_scale = self._get_kernel_with_merged_lora()
 
-        targets = []
+        # Save the variables using the name as the key.
         if mode != "gptq":
-            targets.append(kernel_value)
+            store["kernel"] = kernel_value
         if self.bias is not None:
-            targets.append(self.bias)
-        if merged_kernel_scale is not None and mode in ("int4", "int8"):
-            targets.append(merged_kernel_scale)
-
-        # Append per-mode attributes (order matters)
-        targets.extend(getattr(self, name) for name in MODE_SPEC[mode])
-
-        for i, var in enumerate(targets):
-            store[str(i)] = var
+            store["bias"] = self.bias
+        for name in self.quantization_variable_spec[mode]:
+            if name == "kernel_scale" and mode in ("int4", "int8"):
+                # For int4/int8, the merged LoRA scale (if any) comes from
+                # `_get_kernel_with_merged_lora()`
+                store[name] = merged_kernel_scale
+            else:
+                store[name] = getattr(self, name)
 
     def load_own_variables(self, store):
         if not self.lora_enabled:
@@ -288,41 +262,38 @@ class Dense(Layer):
         # Do nothing if the layer isn't yet built
         if not self.built:
             return
+        mode = self.quantization_mode
+        if mode not in self.quantization_variable_spec:
+            raise self._quantization_mode_error(mode)
+
+        # Determine whether to use the legacy loading method.
+        if "0" in store:
+            return self._legacy_load_own_variables(store)
+
+        # Load the variables using the name as the key.
+        if mode != "gptq":
+            self._kernel.assign(store["kernel"])
+        if self.bias is not None:
+            self.bias.assign(store["bias"])
+        for name in self.quantization_variable_spec[mode]:
+            getattr(self, name).assign(store[name])
+        if self.lora_enabled:
+            self.lora_kernel_a.assign(ops.zeros(self.lora_kernel_a.shape))
+            self.lora_kernel_b.assign(ops.zeros(self.lora_kernel_b.shape))
+
+    def _legacy_load_own_variables(self, store):
         # The keys of the `store` will be saved as determined because the
         # default ordering will change after quantization
         mode = self.quantization_mode
-
-        # Per-mode variable spec (order matters).
-        MODE_SPEC = {
-            None: [],
-            "int8": ["kernel_scale"],
-            "int4": ["kernel_scale"],
-            "float8": [
-                "inputs_scale",
-                "inputs_amax_history",
-                "kernel_scale",
-                "kernel_amax_history",
-                "outputs_grad_scale",
-                "outputs_grad_amax_history",
-            ],
-            "gptq": [
-                "quantized_kernel",
-                "kernel_scale",
-                "kernel_zero",
-                "g_idx",
-            ],
-        }
-
-        if mode not in MODE_SPEC:
-            raise self._quantization_mode_error(mode)
-
         targets = []
         if mode != "gptq":
             targets.append(self._kernel)
         if self.bias is not None:
             targets.append(self.bias)
-        targets.extend(getattr(self, name) for name in MODE_SPEC[mode])
-
+        targets.extend(
+            getattr(self, name)
+            for name in self.quantization_variable_spec[mode]
+        )
         for i, variable in enumerate(targets):
             variable.assign(store[str(i)])
         if self.lora_enabled:
@@ -384,6 +355,34 @@ class Dense(Layer):
                 f"{len(store.keys())} variables during loading. "
                 f"Expected: {[v.name for v in all_vars]}"
             )
+
+    @property
+    def quantization_variable_spec(self):
+        """Returns a dict mapping quantization modes to variable names.
+
+        This spec is used by `save_own_variables` and `load_own_variables` to
+        determine which variables should be saved/loaded for each quantization
+        mode.
+        """
+        return {
+            None: [],
+            "int8": ["kernel_scale"],
+            "int4": ["kernel_scale"],
+            "float8": [
+                "inputs_scale",
+                "inputs_amax_history",
+                "kernel_scale",
+                "kernel_amax_history",
+                "outputs_grad_scale",
+                "outputs_grad_amax_history",
+            ],
+            "gptq": [
+                "quantized_kernel",
+                "kernel_scale",
+                "kernel_zero",
+                "g_idx",
+            ],
+        }
 
     def quantized_build(self, kernel_shape, mode, config=None):
         if mode == "int8":

--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -359,28 +359,36 @@ class DenseTest(testing.TestCase):
         with self.assertRaisesRegex(ValueError, "lora is already enabled"):
             layer.enable_lora(rank=2)
 
-    # Test quantization-related (int8 and float8) methods
+    # Test quantization-related methods.
 
-    def test_quantize_int8(self):
+    @parameterized.named_parameters(
+        ("int8", "int8", 1e-3),
+        ("int4", "int4", 2e-3),
+    )
+    def test_quantize_int(self, mode, error_threshold):
+        if mode == "int4" and testing.tensorflow_uses_gpu():
+            self.skipTest("Segfault")
         layer = layers.Dense(units=16)
         layer.build((None, 8))
         x = np.random.random((2, 8))
         y_float = layer(x)
-        layer.quantize("int8")
+        layer.quantize(mode)
 
-        # Verify weights dtype
+        # Verify the dtype of the weights.
+        # The kernel's data type is int8, despite the int4 quantization, because
+        # we pack the int4 values into int8.
         self.assertEqual(backend.standardize_dtype(layer._kernel.dtype), "int8")
         self.assertEqual(
             backend.standardize_dtype(layer.kernel_scale.dtype),
             layer.variable_dtype,
         )
 
-        # Try eager call and verify output correctness
+        # Verify the correctness of the outputs.
         y_quantized = layer(x)
         mse = ops.mean(ops.square(y_float - y_quantized))
-        self.assertLess(mse, 1e-3)  # A weak correctness test
+        self.assertLess(mse, error_threshold)  # A weak correctness test
 
-        # Try saving and reloading the model
+        # Check model save / load round-trip.
         model = models.Sequential([layer])
         temp_filepath = os.path.join(
             self.get_temp_dir(), "quantized_model.keras"
@@ -389,30 +397,20 @@ class DenseTest(testing.TestCase):
         new_model = saving.load_model(temp_filepath)
         self.assertAllClose(model.predict(x), new_model.predict(x))
 
-        # Try saving and reloading the model's weights only
+        # Check weights-only save / load round-trip.
         temp_filepath = os.path.join(
             self.get_temp_dir(), "quantized_model.weights.h5"
         )
         model.save_weights(temp_filepath)
-
-        # Try lora
-        layer = layers.Dense(units=16)
-        layer.build((None, 8))
-        layer.enable_lora(4)
-        layer.quantize("int8")
-        x = np.random.random((2, 8))
-        _ = layer(x)
-
-        # Try building with quantized dtype policy
-        layer = layers.Dense(units=16, dtype="int8_from_mixed_bfloat16")
-        layer.build((None, 8))
-        self.assertEqual(backend.standardize_dtype(layer._kernel.dtype), "int8")
-        self.assertEqual(
-            backend.standardize_dtype(layer.kernel_scale.dtype), "float32"
-        )
+        new_model = models.Sequential([layers.Dense(units=16)])
+        new_model.build((None, 8))
+        new_model.quantize(mode)
+        new_model.load_weights(temp_filepath)
+        self.assertAllClose(model.predict(x), new_model.predict(x))
 
     @parameterized.named_parameters(
         ("int8", "int8"),
+        ("int4", "int4"),
         ("float8", "float8"),
     )
     def test_quantize_on_unbuilt_layer(self, mode):
@@ -424,6 +422,7 @@ class DenseTest(testing.TestCase):
 
     @parameterized.named_parameters(
         ("int8", "int8"),
+        ("int4", "int4"),
         ("float8", "float8"),
     )
     def test_quantize_on_subclass(self, mode):
@@ -439,13 +438,14 @@ class DenseTest(testing.TestCase):
 
     @parameterized.named_parameters(
         ("int8", "int8"),
+        ("int4", "int4"),
         ("float8", "float8"),
     )
     def test_quantize_when_already_quantized(self, mode):
         layer = layers.Dense(units=2)
         layer.build((None, 2))
         layer.quantize(mode)
-        for m in ["int8", "float8"]:
+        for m in ["int8", "int4", "float8"]:
             with self.assertRaisesRegex(
                 ValueError, "is already quantized with dtype_policy="
             ):
@@ -453,7 +453,7 @@ class DenseTest(testing.TestCase):
 
         layer = layers.Dense(units=2, dtype=f"{mode}_from_float32")
         layer.build((None, 2))
-        for m in ["int8", "float8"]:
+        for m in ["int8", "int4", "float8"]:
             with self.assertRaisesRegex(
                 ValueError, "is already quantized with dtype_policy="
             ):
@@ -461,6 +461,7 @@ class DenseTest(testing.TestCase):
 
     @parameterized.named_parameters(
         ("int8", "int8_from_float32", 3),
+        ("int4", "int4_from_float32", 3),  # bias + packed kernel + scale
         ("float8", "float8_from_float32", 8),
     )
     @pytest.mark.skipif(testing.tensorflow_uses_gpu(), reason="Segfault")
@@ -506,8 +507,8 @@ class DenseTest(testing.TestCase):
 
     @parameterized.named_parameters(
         ("int8", "int8_from_mixed_bfloat16", 1, 2),
-        ("float8", "float8_from_mixed_bfloat16", 8, 0),
         ("int4", "int4_from_mixed_bfloat16", 1, 2),
+        ("float8", "float8_from_mixed_bfloat16", 8, 0),
     )
     @pytest.mark.requires_trainable_backend
     @pytest.mark.skipif(testing.tensorflow_uses_gpu(), reason="Segfault")
@@ -526,20 +527,30 @@ class DenseTest(testing.TestCase):
             supports_masking=True,
         )
 
+    @parameterized.named_parameters(
+        ("int8", "int8", 3, 2, 5),
+        ("int4", "int4", 3, 2, 5),
+    )
     @pytest.mark.requires_trainable_backend
     @pytest.mark.skipif(testing.tensorflow_uses_gpu(), reason="Segfault")
-    def test_quantize_int8_when_lora_enabled(self):
+    def test_quantize_lora_integration(
+        self,
+        mode,
+        num_trainable_weights,
+        num_non_trainable_weights,
+        num_torch_params,
+    ):
         # Note that saving and loading with lora_enabled and quantized are
         # lossy, so we use a weak correctness test for model outputs (atol=0.5).
         config = dict(units=16)
         layer = layers.Dense(**config)
         layer.build((None, 8))
         layer.enable_lora(4)
-        layer.quantize("int8")
-        self.assertLen(layer.trainable_weights, 3)
-        self.assertLen(layer.non_trainable_weights, 2)
+        layer.quantize(mode)
+        self.assertLen(layer.trainable_weights, num_trainable_weights)
+        self.assertLen(layer.non_trainable_weights, num_non_trainable_weights)
         if backend.backend() == "torch":
-            self.assertLen(layer.torch_params, 5)
+            self.assertLen(layer.torch_params, num_torch_params)
 
         # Try calling fit()
         init_lora_a_kernel_value = layer.lora_kernel_a.numpy()
@@ -577,7 +588,7 @@ class DenseTest(testing.TestCase):
         model.save_weights(temp_filepath)
         new_model = models.Sequential([layers.Dense(**config)])
         new_model.build((None, 8))
-        new_model.quantize("int8")
+        new_model.quantize(mode)
         new_model.load_weights(temp_filepath)
         self.assertFalse(new_model.layers[0].lora_enabled)
         self.assertAllClose(model.predict(x), new_model.predict(x), atol=0.5)
@@ -791,177 +802,6 @@ class DenseTest(testing.TestCase):
         y_training = layer(x, training=True)
         self.assertAllClose(y_inference, y_training)
 
-    @pytest.mark.skipif(testing.tensorflow_uses_gpu(), reason="Segfault")
-    def test_quantize_int4(self):
-        """Basic correctness / serialization test for int4 quantization."""
-        layer = layers.Dense(units=16)
-        layer.build((None, 8))
-
-        # Reference (float32) output.
-        x = np.random.random((2, 8))
-        y_float = layer(x)
-
-        # Quantize to int4 and validate kernel dtype / scale dtype.
-        layer.quantize("int4")
-        self.assertEqual(
-            backend.standardize_dtype(layer._kernel.dtype),
-            "int8",  # Packed int4 values are stored as int8
-        )
-        self.assertEqual(
-            backend.standardize_dtype(layer.kernel_scale.dtype),
-            layer.variable_dtype,
-        )
-
-        y_quantized = layer(x)
-        mse = ops.mean(ops.square(y_float - y_quantized))
-        self.assertLess(mse, 15e-4)  # Weak correctness check
-
-        # Check model save / load round-trip.
-        model = models.Sequential([layer])
-        temp_filepath = os.path.join(
-            self.get_temp_dir(), "quantized_int4_model.keras"
-        )
-        model.save(temp_filepath)
-        new_model = saving.load_model(temp_filepath)
-        self.assertAllClose(model.predict(x), new_model.predict(x))
-
-        # Check weights-only save / load round-trip.
-        temp_filepath = os.path.join(
-            self.get_temp_dir(), "quantized_int4_model.weights.h5"
-        )
-        model.save_weights(temp_filepath)
-        new_model = models.Sequential([layers.Dense(units=16)])
-        new_model.build((None, 8))
-        new_model.quantize("int4")
-        new_model.load_weights(temp_filepath)
-        self.assertAllClose(model.predict(x), new_model.predict(x))
-
-    def test_quantize_int4_on_unbuilt_layer(self):
-        layer = layers.Dense(units=2)
-        with self.assertRaisesRegex(
-            ValueError, "Cannot quantize a layer that isn't yet built."
-        ):
-            layer.quantize("int4")
-
-    def test_quantize_int4_on_subclass(self):
-        class MyDense(layers.Dense):
-            pass
-
-        layer = MyDense(units=16)
-        layer.build((None, 8))
-        with self.assertRaises(NotImplementedError):
-            layer.quantize("int4")
-
-        # It should succeed when `type_check=False`.
-        layer.quantize("int4", type_check=False)
-
-    def test_quantize_int4_when_already_quantized(self):
-        layer = layers.Dense(units=2)
-        layer.build((None, 2))
-        layer.quantize("int4")
-        for m in ["int8", "float8", "int4"]:
-            with self.assertRaisesRegex(
-                ValueError, "is already quantized with dtype_policy="
-            ):
-                layer.quantize(m)
-
-        layer = layers.Dense(units=2, dtype="int4_from_float32")
-        layer.build((None, 2))
-        for m in ["int8", "float8", "int4"]:
-            with self.assertRaisesRegex(
-                ValueError, "is already quantized with dtype_policy="
-            ):
-                layer.quantize(m)
-
-    def test_quantize_int4_by_setting_dtype_policy(self):
-        policy = "int4_from_float32"
-        expected_num_variables = 3  # bias + packed kernel + scale
-        layer = layers.Dense(units=2)
-        layer.build((None, 2))
-        layer.dtype_policy = policy
-        self.assertLen(layer.variables, expected_num_variables)
-
-    @pytest.mark.requires_trainable_backend
-    @pytest.mark.skipif(testing.tensorflow_uses_gpu(), reason="Segfault")
-    def test_quantize_int4_when_lora_enabled(self):
-        config = dict(units=16)
-        layer = layers.Dense(**config)
-        layer.build((None, 8))
-        layer.enable_lora(4)
-        layer.quantize("int4")
-        self.assertLen(layer.trainable_weights, 3)
-        self.assertLen(layer.non_trainable_weights, 2)
-        if backend.backend() == "torch":
-            self.assertLen(layer.torch_params, 5)
-
-        # Try calling fit()
-        init_lora_a_kernel_value = layer.lora_kernel_a.numpy()
-        init_lora_b_kernel_value = layer.lora_kernel_b.numpy()
-        x = np.random.random((64, 8))
-        y = np.random.random((64, 16))
-        model = models.Sequential([layer])
-        model.compile(optimizer="sgd", loss="mse")
-        model.fit(x, y, epochs=2)
-
-        final_lora_a_kernel_value = layer.lora_kernel_a.numpy()
-        final_lora_b_kernel_value = layer.lora_kernel_b.numpy()
-        diff_a = np.max(
-            np.abs(init_lora_a_kernel_value - final_lora_a_kernel_value)
-        )
-        diff_b = np.max(
-            np.abs(init_lora_b_kernel_value - final_lora_b_kernel_value)
-        )
-        self.assertGreater(diff_a, 0.0)
-        self.assertGreater(diff_b, 0.0)
-
-        # Save & reload full model
-        model = models.Sequential([layer])
-        temp_filepath = os.path.join(
-            self.get_temp_dir(), "quantized_int4_lora_model.keras"
-        )
-        model.save(temp_filepath)
-        new_model = saving.load_model(temp_filepath)
-        self.assertTrue(new_model.layers[0].lora_enabled)
-        self.assertAllClose(model.predict(x), new_model.predict(x), atol=0.5)
-
-        # Save & reload weights only
-        temp_filepath = os.path.join(
-            self.get_temp_dir(), "quantized_int4_lora_model.weights.h5"
-        )
-        model.save_weights(temp_filepath)
-        new_model = models.Sequential([layers.Dense(**config)])
-        new_model.build((None, 8))
-        new_model.quantize("int4")
-        new_model.load_weights(temp_filepath)
-        self.assertFalse(new_model.layers[0].lora_enabled)
-        self.assertAllClose(model.predict(x), new_model.predict(x), atol=0.5)
-
-        # Try loading a normal checkpoint into a lora model
-        new_model.save_weights(temp_filepath)
-        model.load_weights(temp_filepath)
-        self.assertAllClose(model.predict(x), new_model.predict(x), atol=0.5)
-
-        # Test export and TFSMLayer reloading when using tensorflow backend
-        if backend.backend() == "tensorflow":
-            import tensorflow as tf
-
-            temp_filepath = os.path.join(self.get_temp_dir(), "exported_model")
-            ref_input = tf.random.normal((2, 8))
-            ref_output = model(ref_input)
-            model.export(temp_filepath, format="tf_saved_model")
-            reloaded_layer = export.TFSMLayer(temp_filepath)
-            self.assertAllClose(
-                reloaded_layer(ref_input), ref_output, atol=1e-7
-            )
-            self.assertLen(reloaded_layer.weights, len(model.weights))
-            self.assertLen(
-                reloaded_layer.trainable_weights, len(model.trainable_weights)
-            )
-            self.assertLen(
-                reloaded_layer.non_trainable_weights,
-                len(model.non_trainable_weights),
-            )
-
     def test_gptq_serialization(self):
         """Test that a GPTQ-quantized layer can be serialized and deserialized
         correctly."""
@@ -987,3 +827,74 @@ class DenseTest(testing.TestCase):
         self.assertAllClose(
             layer.kernel, quantizers.unpack_int4(packed_kernel, 2)
         )
+
+    def test_legacy_load_own_variables(self):
+        # In previous versions, `load_own_variables` accepted a store with
+        # numeric keys.
+        # TODO(JyotinderSingh): add gptq_store test.
+        float32_store = {
+            "0": np.random.random((8, 16)).astype("float32"),
+            "1": np.random.random((16,)).astype("float32"),
+        }
+        int8_store = {
+            "0": np.random.randint(-128, 127, size=(8, 16), dtype="int8"),
+            "1": np.random.random((16,)).astype("float32"),
+            "2": np.random.random((16,)).astype("float32"),  # kernel_scale.
+        }
+        int4_store = {
+            "0": np.random.randint(-128, 127, size=(4, 16), dtype="int8"),
+            "1": np.random.random((16,)).astype("float32"),
+            "2": np.random.random((16,)).astype("float32"),  # kernel_scale.
+        }
+        float8_store = {
+            "0": np.random.random((8, 16)).astype("float32"),
+            "1": np.random.random((16,)).astype("float32"),
+            # inputs_scale.
+            "2": np.random.random(()).astype("float32"),
+            # inputs_amax_history.
+            "3": np.random.random((1024,)).astype("float32"),
+            # kernel_scale.
+            "4": np.random.random(()).astype("float32"),
+            # kernel_amax_history.
+            "5": np.random.random((1024,)).astype("float32"),
+            # outputs_grad_scale.
+            "6": np.random.random(()).astype("float32"),
+            # outputs_grad_amax_history.
+            "7": np.random.random((1024,)).astype("float32"),
+        }
+
+        # Test float32 layer.
+        layer = layers.Dense(units=16)
+        layer.build((None, 8))
+        layer.load_own_variables(float32_store)
+        self.assertAllClose(layer._kernel, float32_store["0"])
+        self.assertAllClose(layer.bias, float32_store["1"])
+
+        # Test int8-quantized layer.
+        layer = layers.Dense(units=16, dtype="int8_from_float32")
+        layer.build((None, 8))
+        layer.load_own_variables(int8_store)
+        self.assertAllClose(layer._kernel, int8_store["0"])
+        self.assertAllClose(layer.bias, int8_store["1"])
+        self.assertAllClose(layer.kernel_scale, int8_store["2"])
+
+        # Test int4-quantized layer.
+        layer = layers.Dense(units=16, dtype="int4_from_float32")
+        layer.build((None, 8))
+        layer.load_own_variables(int4_store)
+        self.assertAllClose(layer._kernel, int4_store["0"])
+        self.assertAllClose(layer.bias, int4_store["1"])
+        self.assertAllClose(layer.kernel_scale, int4_store["2"])
+
+        # Test float8-quantized layer.
+        layer = layers.Dense(units=16, dtype="float8_from_float32")
+        layer.build((None, 8))
+        layer.load_own_variables(float8_store)
+        self.assertAllClose(layer._kernel, float8_store["0"])
+        self.assertAllClose(layer.bias, float8_store["1"])
+        self.assertAllClose(layer.inputs_scale, float8_store["2"])
+        self.assertAllClose(layer.inputs_amax_history, float8_store["3"])
+        self.assertAllClose(layer.kernel_scale, float8_store["4"])
+        self.assertAllClose(layer.kernel_amax_history, float8_store["5"])
+        self.assertAllClose(layer.outputs_grad_scale, float8_store["6"])
+        self.assertAllClose(layer.outputs_grad_amax_history, float8_store["7"])

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -299,52 +299,26 @@ class EinsumDense(Layer):
         # Do nothing if the layer isn't yet built
         if not self.built:
             return
-        # The keys of the `store` will be saved as determined because the
-        # default ordering will change after quantization
         mode = self.quantization_mode
-
-        # For int4/int8, the merged LoRA scale (if any) comes from
-        # `_get_kernel_with_merged_lora()` and is appended below.
-        MODE_SPEC = {
-            None: [],
-            "int4": [],
-            "int8": [],
-            "float8": [
-                "inputs_scale",
-                "inputs_amax_history",
-                "kernel_scale",
-                "kernel_amax_history",
-                "outputs_grad_scale",
-                "outputs_grad_amax_history",
-            ],
-            "gptq": [
-                "quantized_kernel",
-                "kernel_scale",
-                "kernel_zero",
-                "g_idx",
-            ],
-        }
-
-        if mode not in MODE_SPEC:
+        if mode not in self.quantization_variable_spec:
             raise self._quantization_mode_error(mode)
 
         # Kernel plus optional merged LoRA-aware scale (returns (kernel, None)
         # for None/gptq)
         kernel_value, merged_kernel_scale = self._get_kernel_with_merged_lora()
 
-        targets = []
+        # Save the variables using the name as the key.
         if mode != "gptq":
-            targets.append(kernel_value)
+            store["kernel"] = kernel_value
         if self.bias is not None:
-            targets.append(self.bias)
-        if merged_kernel_scale is not None and mode in ("int4", "int8"):
-            targets.append(merged_kernel_scale)
-
-        # Append per-mode attributes (order matters)
-        targets.extend(getattr(self, name) for name in MODE_SPEC[mode])
-
-        for i, var in enumerate(targets):
-            store[str(i)] = var
+            store["bias"] = self.bias
+        for name in self.quantization_variable_spec[mode]:
+            if name == "kernel_scale" and mode in ("int4", "int8"):
+                # For int4/int8, the merged LoRA scale (if any) comes from
+                # `_get_kernel_with_merged_lora()`
+                store[name] = merged_kernel_scale
+            else:
+                store[name] = getattr(self, name)
 
     def load_own_variables(self, store):
         if not self.lora_enabled:
@@ -352,42 +326,38 @@ class EinsumDense(Layer):
         # Do nothing if the layer isn't yet built
         if not self.built:
             return
+        mode = self.quantization_mode
+        if mode not in self.quantization_variable_spec:
+            raise self._quantization_mode_error(mode)
+
+        # Determine whether to use the legacy loading method.
+        if "0" in store:
+            return self._legacy_load_own_variables(store)
+
+        # Load the variables using the name as the key.
+        if mode != "gptq":
+            self._kernel.assign(store["kernel"])
+        if self.bias is not None:
+            self.bias.assign(store["bias"])
+        for name in self.quantization_variable_spec[mode]:
+            getattr(self, name).assign(store[name])
+        if self.lora_enabled:
+            self.lora_kernel_a.assign(ops.zeros(self.lora_kernel_a.shape))
+            self.lora_kernel_b.assign(ops.zeros(self.lora_kernel_b.shape))
+
+    def _legacy_load_own_variables(self, store):
         # The keys of the `store` will be saved as determined because the
         # default ordering will change after quantization
         mode = self.quantization_mode
-
-        # Per-mode variable spec (order matters).
-        MODE_SPEC = {
-            None: [],
-            "int8": ["kernel_scale"],
-            "int4": ["kernel_scale"],
-            "float8": [
-                "inputs_scale",
-                "inputs_amax_history",
-                "kernel_scale",
-                "kernel_amax_history",
-                "outputs_grad_scale",
-                "outputs_grad_amax_history",
-            ],
-            "gptq": [
-                "quantized_kernel",
-                "kernel_scale",
-                "kernel_zero",
-                "g_idx",
-            ],
-        }
-
-        if mode not in MODE_SPEC:
-            raise self._quantization_mode_error(mode)
-
         targets = []
-
         if mode != "gptq":
             targets.append(self._kernel)
         if self.bias is not None:
             targets.append(self.bias)
-        targets.extend(getattr(self, name) for name in MODE_SPEC[mode])
-
+        targets.extend(
+            getattr(self, name)
+            for name in self.quantization_variable_spec[mode]
+        )
         for i, variable in enumerate(targets):
             variable.assign(store[str(i)])
         if self.lora_enabled:
@@ -453,6 +423,34 @@ class EinsumDense(Layer):
                 f"{len(store.keys())} variables during loading. "
                 f"Expected: {[v.name for v in all_vars]}"
             )
+
+    @property
+    def quantization_variable_spec(self):
+        """Returns a dict mapping quantization modes to variable names.
+
+        This spec is used by `save_own_variables` and `load_own_variables` to
+        determine which variables should be saved/loaded for each quantization
+        mode.
+        """
+        return {
+            None: [],
+            "int8": ["kernel_scale"],
+            "int4": ["kernel_scale"],
+            "float8": [
+                "inputs_scale",
+                "inputs_amax_history",
+                "kernel_scale",
+                "kernel_amax_history",
+                "outputs_grad_scale",
+                "outputs_grad_amax_history",
+            ],
+            "gptq": [
+                "quantized_kernel",
+                "kernel_scale",
+                "kernel_zero",
+                "g_idx",
+            ],
+        }
 
     def quantized_build(self, kernel_shape, mode, config=None):
         if mode == "int8":

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -425,12 +425,13 @@ class EinsumDenseTest(testing.TestCase):
             supports_masking=False,
         )
 
-    # Test quantization-related (int8 and float8) methods
+    # Test quantization-related methods.
+
     @parameterized.named_parameters(
-        ("int8", "int8"),
-        ("int4", "int4"),
+        ("int8", "int8", 1e-3),
+        ("int4", "int4", 3e-3),
     )
-    def test_quantize(self, quantization_mode):
+    def test_quantize_int(self, mode, error_threshold):
         layer = layers.EinsumDense(
             equation="ab,bcd->acd",
             output_shape=(8, 32),
@@ -439,7 +440,7 @@ class EinsumDenseTest(testing.TestCase):
         layer.build((None, 3))
         x = np.random.random((2, 3))
         y_float = layer(x)
-        layer.quantize(quantization_mode)
+        layer.quantize(mode)
 
         # Verify weights dtype
         self.assertEqual(backend.standardize_dtype(layer._kernel.dtype), "int8")
@@ -451,7 +452,7 @@ class EinsumDenseTest(testing.TestCase):
         # Try eager call and verify output correctness
         y_quantized = layer(x)
         mse = ops.mean(ops.square(y_float - y_quantized))
-        self.assertLess(mse, 1e-3)  # A weak correctness test
+        self.assertLess(mse, error_threshold)  # A weak correctness test
 
         # Try saving and reloading the model
         model = models.Sequential([layer])
@@ -468,24 +469,12 @@ class EinsumDenseTest(testing.TestCase):
         )
         model.save_weights(temp_filepath)
 
-        # Try lora
-        layer = layers.EinsumDense(
-            equation="ab,bcd->acd",
-            output_shape=(8, 32),
-            bias_axes="d",
-        )
-        layer.build((None, 3))
-        layer.enable_lora(2)
-        layer.quantize(quantization_mode)
-        x = np.random.random((2, 3))
-        _ = layer(x)
-
         # Try building with quantized dtype policy
         layer = layers.EinsumDense(
             equation="abcde,afce->acdbf",  # Test reduce and transpose
             output_shape=(2, 4, 8, 16),
             bias_axes="d",
-            dtype=f"{quantization_mode}_from_mixed_bfloat16",
+            dtype=f"{mode}_from_mixed_bfloat16",
         )
         layer.build((1, 8, 2, 4, 32))
         self.assertEqual(backend.standardize_dtype(layer._kernel.dtype), "int8")
@@ -495,7 +484,7 @@ class EinsumDenseTest(testing.TestCase):
         layer = layers.EinsumDense(
             equation="a,b->ab",  # Test expand
             output_shape=(4,),
-            dtype=f"{quantization_mode}_from_float32",
+            dtype=f"{mode}_from_float32",
         )
         layer.build((None,))
         self.assertEqual(backend.standardize_dtype(layer._kernel.dtype), "int8")
@@ -537,7 +526,7 @@ class EinsumDenseTest(testing.TestCase):
             "btnh,nhd->btd",
             (None, 8),
             (1, 2, 2, 4),
-            2e-3,
+            3e-3,
         ),
         (
             "int4_btd,ndh->btnh",
@@ -545,7 +534,7 @@ class EinsumDenseTest(testing.TestCase):
             "btd,ndh->btnh",
             (None, 2, 8),
             (1, 2, 4),
-            2e-3,
+            3e-3,
         ),
         (
             "int4_btd,df->btf",
@@ -741,7 +730,7 @@ class EinsumDenseTest(testing.TestCase):
         ),
     )
     @pytest.mark.requires_trainable_backend
-    def test_quantize_when_lora_enabled(
+    def test_quantize_lora_integration(
         self, quantization_mode, equation, input_shape, output_shape
     ):
         config = dict(
@@ -1050,3 +1039,79 @@ class EinsumDenseTest(testing.TestCase):
         self.assertAllClose(
             layer.kernel, quantizers.unpack_int4(packed_kernel, 2)
         )
+
+    def test_legacy_load_own_variables(self):
+        # In previous versions, `load_own_variables` accepted a store with
+        # numeric keys.
+        # TODO(JyotinderSingh): add gptq_store test.
+        float32_store = {
+            "0": np.random.random((3, 8, 32)).astype("float32"),
+            "1": np.random.random((32,)).astype("float32"),
+        }
+        int8_store = {
+            "0": np.random.randint(-128, 127, size=(3, 8, 32), dtype="int8"),
+            "1": np.random.random((32,)).astype("float32"),
+            "2": np.random.random((1, 8, 32)).astype("float32"),
+        }
+        int4_store = {
+            "0": np.random.randint(-128, 127, size=(2, 8, 32), dtype="int8"),
+            "1": np.random.random((32,)).astype("float32"),
+            "2": np.random.random((1, 8, 32)).astype("float32"),
+        }
+        float8_store = {
+            "0": np.random.random((3, 8, 32)).astype("float32"),
+            "1": np.random.random((32,)).astype("float32"),
+            # inputs_scale.
+            "2": np.random.random(()).astype("float32"),
+            # inputs_amax_history.
+            "3": np.random.random((1024,)).astype("float32"),
+            # kernel_scale.
+            "4": np.random.random(()).astype("float32"),
+            # kernel_amax_history.
+            "5": np.random.random((1024,)).astype("float32"),
+            # outputs_grad_scale.
+            "6": np.random.random(()).astype("float32"),
+            # outputs_grad_amax_history.
+            "7": np.random.random((1024,)).astype("float32"),
+        }
+        config = dict(
+            equation="ab,bcd->acd",
+            output_shape=(8, 32),
+            bias_axes="d",
+        )
+
+        # Test float32 layer.
+        layer = layers.EinsumDense(**config)
+        layer.build((None, 3))
+        layer.load_own_variables(float32_store)
+        self.assertAllClose(layer._kernel, float32_store["0"])
+        self.assertAllClose(layer.bias, float32_store["1"])
+
+        # Test int8-quantized layer.
+        layer = layers.EinsumDense(**config, dtype="int8_from_float32")
+        layer.build((None, 3))
+        layer.load_own_variables(int8_store)
+        self.assertAllClose(layer._kernel, int8_store["0"])
+        self.assertAllClose(layer.bias, int8_store["1"])
+        self.assertAllClose(layer.kernel_scale, int8_store["2"])
+
+        # Test int4-quantized layer.
+        layer = layers.EinsumDense(**config, dtype="int4_from_float32")
+        layer.build((None, 3))
+        layer.load_own_variables(int4_store)
+        self.assertAllClose(layer._kernel, int4_store["0"])
+        self.assertAllClose(layer.bias, int4_store["1"])
+        self.assertAllClose(layer.kernel_scale, int4_store["2"])
+
+        # Test float8-quantized layer.
+        layer = layers.EinsumDense(**config, dtype="float8_from_float32")
+        layer.build((None, 3))
+        layer.load_own_variables(float8_store)
+        self.assertAllClose(layer._kernel, float8_store["0"])
+        self.assertAllClose(layer.bias, float8_store["1"])
+        self.assertAllClose(layer.inputs_scale, float8_store["2"])
+        self.assertAllClose(layer.inputs_amax_history, float8_store["3"])
+        self.assertAllClose(layer.kernel_scale, float8_store["4"])
+        self.assertAllClose(layer.kernel_amax_history, float8_store["5"])
+        self.assertAllClose(layer.outputs_grad_scale, float8_store["6"])
+        self.assertAllClose(layer.outputs_grad_amax_history, float8_store["7"])

--- a/keras/src/layers/core/embedding.py
+++ b/keras/src/layers/core/embedding.py
@@ -120,9 +120,9 @@ class Embedding(Layer):
         if self.built:
             return
         embeddings_shape = (self.input_dim, self.output_dim)
-        if self.quantization_mode is not None:
+        if self.quantization_mode:
             self.quantized_build(embeddings_shape, mode=self.quantization_mode)
-        if self.quantization_mode != "int8":
+        if self.quantization_mode not in ("int8", "int4"):
             self._embeddings = self.add_weight(
                 shape=embeddings_shape,
                 initializer=self.embeddings_initializer,
@@ -137,12 +137,20 @@ class Embedding(Layer):
 
     @property
     def embeddings(self):
+        if not self.built:
+            raise AttributeError(
+                "You must build the layer before accessing `embeddings`."
+            )
+        embeddings = self._embeddings
+        if self.quantization_mode == "int4":
+            embeddings = quantizers.unpack_int4(
+                embeddings, self._orig_output_dim, axis=-1
+            )
         if self.lora_enabled:
-            return self._embeddings + (
-                self.lora_alpha / self.lora_rank
-            ) * ops.matmul(self.lora_embeddings_a, self.lora_embeddings_b)
-
-        return self._embeddings
+            return embeddings + (self.lora_alpha / self.lora_rank) * ops.matmul(
+                self.lora_embeddings_a, self.lora_embeddings_b
+            )
+        return embeddings
 
     def call(self, inputs):
         if inputs.dtype != "int32" and inputs.dtype != "int64":
@@ -189,13 +197,13 @@ class Embedding(Layer):
         self._tracker.unlock()
         self.lora_embeddings_a = self.add_weight(
             name="lora_embeddings_a",
-            shape=(self.embeddings.shape[0], rank),
+            shape=(self.input_dim, rank),
             initializer=initializers.get(a_initializer),
             regularizer=self.embeddings_regularizer,
         )
         self.lora_embeddings_b = self.add_weight(
             name="lora_embeddings_b",
-            shape=(rank, self.embeddings.shape[1]),
+            shape=(rank, self.output_dim),
             initializer=initializers.get(b_initializer),
             regularizer=self.embeddings_regularizer,
         )
@@ -209,19 +217,25 @@ class Embedding(Layer):
         # Do nothing if the layer isn't yet built
         if not self.built:
             return
-        # The keys of the `store` will be saved as determined because the
-        # default ordering will change after quantization
-        embeddings_value, embeddings_scale = (
+        mode = self.quantization_mode
+        if mode not in self.quantization_variable_spec:
+            raise self._quantization_mode_error(mode)
+
+        # Embeddings plus optional merged LoRA-aware scale
+        # (returns (kernel, None) for None/gptq).
+        embeddings_value, merged_kernel_scale = (
             self._get_embeddings_with_merged_lora()
         )
-        target_variables = [embeddings_value]
-        if self.quantization_mode is not None:
-            if self.quantization_mode == "int8":
-                target_variables.append(embeddings_scale)
+
+        # Save the variables using the name as the key.
+        store["embeddings"] = embeddings_value
+        for name in self.quantization_variable_spec[mode]:
+            if name == "embeddings_scale" and mode in ("int4", "int8"):
+                # For int4/int8, the merged LoRA scale (if any) comes from
+                # `_get_embeddings_with_merged_lora()`
+                store[name] = merged_kernel_scale
             else:
-                raise self._quantization_mode_error(self.quantization_mode)
-        for i, variable in enumerate(target_variables):
-            store[str(i)] = variable
+                store[name] = getattr(self, name)
 
     def load_own_variables(self, store):
         if not self.lora_enabled:
@@ -229,15 +243,36 @@ class Embedding(Layer):
         # Do nothing if the layer isn't yet built
         if not self.built:
             return
+        mode = self.quantization_mode
+        if mode not in self.quantization_variable_spec:
+            raise self._quantization_mode_error(mode)
+
+        # Determine whether to use the legacy loading method.
+        if "0" in store:
+            return self._legacy_load_own_variables(store)
+
+        # Load the variables using the name as the key.
+        self._embeddings.assign(store["embeddings"])
+        for name in self.quantization_variable_spec[mode]:
+            getattr(self, name).assign(store[name])
+        if self.lora_enabled:
+            self.lora_embeddings_a.assign(
+                ops.zeros(self.lora_embeddings_a.shape)
+            )
+            self.lora_embeddings_b.assign(
+                ops.zeros(self.lora_embeddings_b.shape)
+            )
+
+    def _legacy_load_own_variables(self, store):
         # The keys of the `store` will be saved as determined because the
         # default ordering will change after quantization
-        target_variables = [self._embeddings]
-        if self.quantization_mode is not None:
-            if self.quantization_mode == "int8":
-                target_variables.append(self.embeddings_scale)
-            else:
-                raise self._quantization_mode_error(self.quantization_mode)
-        for i, variable in enumerate(target_variables):
+        mode = self.quantization_mode
+        targets = [self._embeddings]
+        targets.extend(
+            getattr(self, name)
+            for name in self.quantization_variable_spec[mode]
+        )
+        for i, variable in enumerate(targets):
             variable.assign(store[str(i)])
         if self.lora_enabled:
             self.lora_embeddings_a.assign(
@@ -305,17 +340,31 @@ class Embedding(Layer):
                 f"Expected: {[v.name for v in all_vars]}"
             )
 
-    """Quantization-related (int8) methods"""
-
     def _quantization_mode_error(self, mode):
         return NotImplementedError(
-            "Invalid quantization mode. Expected 'int8'. "
+            "Invalid quantization mode. Expected one of ('int8', 'int4'). "
             f"Received: quantization_mode={mode}"
         )
+
+    @property
+    def quantization_variable_spec(self):
+        """Returns a dict mapping quantization modes to variable names.
+
+        This spec is used by `save_own_variables` and `load_own_variables` to
+        determine which variables should be saved/loaded for each quantization
+        mode.
+        """
+        return {
+            None: [],
+            "int8": ["embeddings_scale"],
+            "int4": ["embeddings_scale"],
+        }
 
     def quantized_build(self, embeddings_shape, mode):
         if mode == "int8":
             self._int8_build(embeddings_shape)
+        elif mode == "int4":
+            self._int4_build(embeddings_shape)
         else:
             raise self._quantization_mode_error(mode)
         self._is_quantized = True
@@ -338,10 +387,27 @@ class Embedding(Layer):
             trainable=False,
         )
 
-    def quantized_call(self, *args, **kwargs):
-        if self.quantization_mode != "int8":
-            raise self._quantization_mode_error(self.quantization_mode)
-        return super().quantized_call(*args, **kwargs)
+    def _int4_build(self, embeddings_shape):
+        input_dim, output_dim = embeddings_shape
+        packed_rows = (output_dim + 1) // 2  # ceil for odd dims
+
+        # Embeddings are stored *packed*: each int8 byte contains two int4
+        # values.
+        self._embeddings = self.add_weight(
+            name="embeddings",
+            shape=(input_dim, packed_rows),
+            initializer="zeros",
+            dtype="int8",
+            trainable=False,
+        )
+        self.embeddings_scale = self.add_weight(
+            name="embeddings_scale",
+            shape=(self.input_dim,),
+            initializer="ones",
+            trainable=False,
+        )
+        # Record original output_dim for unpacking at runtime.
+        self._orig_output_dim = output_dim
 
     def _int8_call(self, inputs, training=None):
         # We cannot update quantized self._embeddings, so the custom gradient is
@@ -363,49 +429,151 @@ class Embedding(Layer):
             )
         return outputs
 
+    def _int4_call(self, inputs, training=None):
+        # We cannot update quantized self._embeddings, so the custom gradient is
+        # not needed
+        if backend.standardize_dtype(inputs.dtype) not in ("int32", "int64"):
+            inputs = ops.cast(inputs, "int32")
+        embeddings_scale = ops.take(self.embeddings_scale, inputs, axis=0)
+        unpacked_embeddings = quantizers.unpack_int4(
+            self._embeddings, self._orig_output_dim, axis=-1
+        )
+        outputs = ops.take(unpacked_embeddings, inputs, axis=0)
+        # De-scale outputs
+        outputs = ops.divide(
+            ops.cast(outputs, dtype=self.compute_dtype),
+            ops.expand_dims(embeddings_scale, axis=-1),
+        )
+        if self.lora_enabled:
+            lora_outputs = ops.take(self.lora_embeddings_a, inputs, axis=0)
+            lora_outputs = ops.matmul(lora_outputs, self.lora_embeddings_b)
+            outputs = ops.add(
+                outputs, (self.lora_alpha / self.lora_rank) * lora_outputs
+            )
+        return outputs
+
     def quantize(self, mode, type_check=True, config=None):
-        # Prevent quantization of the subclasses
+        # Prevent quantization of the subclasses.
         if type_check and (type(self) is not Embedding):
             raise self._not_implemented_error(self.quantize)
 
         embeddings_shape = (self.input_dim, self.output_dim)
         if mode == "int8":
             # Quantize `self._embeddings` to int8 and compute corresponding
-            # scale
+            # scale.
             embeddings_value, embeddings_scale = quantizers.abs_max_quantize(
                 self._embeddings, axis=-1, to_numpy=True
             )
             embeddings_scale = ops.squeeze(embeddings_scale, axis=-1)
             del self._embeddings
-        self.quantized_build(embeddings_shape, mode)
-        if mode == "int8":
+            self.quantized_build(embeddings_shape, mode)
             self._embeddings.assign(embeddings_value)
             self.embeddings_scale.assign(embeddings_scale)
+        elif mode == "int4":
+            # Quantize to int4 values (stored in int8 dtype, range [-8, 7]).
+            embeddings_value, embeddings_scale = quantizers.abs_max_quantize(
+                self._embeddings,
+                axis=-1,
+                value_range=(-8, 7),
+                dtype="int8",
+                to_numpy=True,
+            )
+            embeddings_scale = ops.squeeze(embeddings_scale, axis=-1)
+            # 2. Pack two int4 values into a single int8 byte.
+            packed_embeddings_value, _, _ = quantizers.pack_int4(
+                embeddings_value, axis=-1
+            )
+            del self._embeddings
+            self.quantized_build(embeddings_shape, mode)
+            self._embeddings.assign(packed_embeddings_value)
+            self.embeddings_scale.assign(embeddings_scale)
+        else:
+            raise self._quantization_mode_error(mode)
 
-        # Set new dtype policy
+        # Set new dtype policy.
         if self.dtype_policy.quantization_mode is None:
             policy = dtype_policies.get(f"{mode}_from_{self.dtype_policy.name}")
             self.dtype_policy = policy
 
     def _get_embeddings_with_merged_lora(self):
-        if self.dtype_policy.quantization_mode is not None:
-            embeddings_value = self._embeddings
-            embeddings_scale = self.embeddings_scale
-            if self.lora_enabled:
-                # Dequantize & quantize to merge lora weights into embeddings
-                # Note that this is a lossy compression
-                embeddings_value = ops.divide(
-                    embeddings_value, ops.expand_dims(embeddings_scale, axis=-1)
-                )
-                embeddings_value = ops.add(
-                    embeddings_value,
-                    ops.matmul(self.lora_embeddings_a, self.lora_embeddings_b),
-                )
-                embeddings_value, embeddings_scale = (
-                    quantizers.abs_max_quantize(
-                        embeddings_value, axis=-1, to_numpy=True
-                    )
-                )
-                embeddings_scale = ops.squeeze(embeddings_scale, axis=-1)
+        """Returns the embeddings with LoRA matrices merged, for serialization.
+
+        This method is called by `save_own_variables` to produce a single
+        embeddings tensor that includes the adaptations from LoRA. This is
+        useful for deploying the model or for continuing training after
+        permanently applying the LoRA update.
+
+        If the layer is quantized (`int8` or `int4`), the process is:
+        1. Dequantize the base embeddings to float.
+        2. Compute the LoRA delta (`lora_embeddings_a @ lora_embeddings_b`) and
+            add it to the dequantized embeddings.
+        3. Re-quantize the merged result back to the original quantized
+            type (`int8` or packed `int4`), calculating a new scale factor.
+
+        If the layer is not quantized, this method returns the result of the
+        `embeddings` property (which computes the merge in floating-point) and a
+        scale of `None`.
+
+        If LoRA is not enabled, it returns the original embeddings and scale
+        without modification.
+
+        Returns:
+            A tuple `(embeddings_value, embeddings_scale)`:
+                `embeddings_value`: The merged embeddings. A quantized tensor if
+                    quantization is active, otherwise a high precision tensor.
+                `embeddings_scale`: The quantization scale for the merged
+                    embeddings. This is `None` if the layer is not quantized.
+        """
+        if self.dtype_policy.quantization_mode in (None, "gptq"):
+            return self.embeddings, None
+
+        embeddings_value = self._embeddings
+        embeddings_scale = self.embeddings_scale
+        if not self.lora_enabled:
             return embeddings_value, embeddings_scale
-        return self.embeddings, None
+
+        # Dequantize embeddings to float.
+        if self.quantization_mode == "int4":
+            unpacked_embeddings = quantizers.unpack_int4(
+                embeddings_value, self._orig_output_dim, axis=-1
+            )
+            float_embeddings = ops.divide(
+                ops.cast(unpacked_embeddings, self.compute_dtype),
+                ops.expand_dims(embeddings_scale, axis=-1),
+            )
+            quant_range = (-8, 7)
+        elif self.quantization_mode == "int8":
+            float_embeddings = ops.divide(
+                ops.cast(embeddings_value, self.compute_dtype),
+                ops.expand_dims(embeddings_scale, axis=-1),
+            )
+            quant_range = (-127, 127)
+        else:
+            raise ValueError(
+                f"Unsupported quantization mode: {self.quantization_mode}"
+            )
+
+        # Merge LoRA weights in float domain.
+        lora_delta = (self.lora_alpha / self.lora_rank) * ops.matmul(
+            self.lora_embeddings_a, self.lora_embeddings_b
+        )
+        merged_float_embeddings = ops.add(float_embeddings, lora_delta)
+
+        # Requantize.
+        requantized_embeddings, embeddings_scale = quantizers.abs_max_quantize(
+            merged_float_embeddings,
+            axis=-1,
+            value_range=quant_range,
+            dtype="int8",
+            to_numpy=True,
+        )
+        embeddings_scale = ops.squeeze(embeddings_scale, axis=-1)
+
+        # Pack if int4.
+        if self.quantization_mode == "int4":
+            embeddings_value, _, _ = quantizers.pack_int4(
+                requantized_embeddings, axis=-1
+            )
+        else:
+            embeddings_value = requantized_embeddings
+        return embeddings_value, embeddings_scale

--- a/keras/src/saving/file_editor_test.py
+++ b/keras/src/saving/file_editor_test.py
@@ -42,7 +42,7 @@ class SavingTest(testing.TestCase):
         out = editor.compare(target_model)  # Fails
 
         editor.add_object(
-            "layers/dense_3", weights={"0": np.random.random((3, 3))}
+            "layers/dense_3", weights={"kernel": np.random.random((3, 3))}
         )
         out = editor.compare(target_model)  # Fails
         self.assertEqual(out["status"], "error")
@@ -50,7 +50,7 @@ class SavingTest(testing.TestCase):
 
         editor.rename_object("dense_3", "dense_4")
         editor.rename_object("layers/dense_4", "dense_2")
-        editor.add_weights("dense_2", weights={"1": np.random.random((3,))})
+        editor.add_weights("dense_2", weights={"bias": np.random.random((3,))})
         out = editor.compare(target_model)  # Succeeds
         self.assertEqual(out["status"], "success")
 
@@ -75,18 +75,18 @@ class SavingTest(testing.TestCase):
         out = editor.compare(target_model)  # Succeeds
         self.assertEqual(out["status"], "success")
 
-        editor.delete_weight("dense_2", "1")
+        editor.delete_weight("dense_2", "bias")
         out = editor.compare(target_model)  # Fails
         self.assertEqual(out["status"], "error")
         self.assertEqual(out["error_count"], 1)
 
-        editor.add_weights("dense_2", {"1": np.zeros((7,))})
+        editor.add_weights("dense_2", {"bias": np.zeros((7,))})
         out = editor.compare(target_model)  # Fails
         self.assertEqual(out["status"], "error")
         self.assertEqual(out["error_count"], 1)
 
-        editor.delete_weight("dense_2", "1")
-        editor.add_weights("dense_2", {"1": np.zeros((3,))})
+        editor.delete_weight("dense_2", "bias")
+        editor.add_weights("dense_2", {"bias": np.zeros((3,))})
         out = editor.compare(target_model)  # Succeeds
         self.assertEqual(out["status"], "success")
 


### PR DESCRIPTION
Recreated from original PR: https://github.com/keras-team/keras/pull/21681

`load_own_variables` for legacy models will now detect the key values of the incoming `store` and use `_legacy_load_own_variables`.

This PR adds a comprehensive `test_legacy_load_own_variables` and simplifies the quantization tests by consolidating the `int8` and `int4` tests.

@JyotinderSingh @hertschuh  
Let me know if this looks good. If so, I will refactor other layers as well.